### PR TITLE
Merge from integration_2022-06-27_16.35 to main (Cray-HPE/sat-podman) 06-27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2022-06-27
+
+### Changed
+- Bumped the default tag for the ``cray/cray-sat`` container image that is
+  specified in the wrapper scripts from 3.16.1-20220608212829_ab4cc61 to
+  3.17.0-20220627210641_7dd2953.
+
 ## [1.8.5] - 2022-06-27
 
 ### Changed

--- a/cray-sat-podman.spec
+++ b/cray-sat-podman.spec
@@ -49,7 +49,7 @@ sat-podman is a wrapper to run the SAT CLI under podman
 for f in sat-podman.sh sat-manpage.sh; do
     # Use registry.local as it will work for both air-gapped and online installs
     sed -e 's,@DEFAULT_SAT_REPOSITORY@,registry.local/cray/cray-sat,' \
-        -e 's,@DEFAULT_SAT_TAG@,3.16.1-20220608212829_ab4cc61,' \
+        -e 's,@DEFAULT_SAT_TAG@,3.17.0-20220627210641_7dd2953,' \
         -i $f
 done
 # Build man pages


### PR DESCRIPTION
CRAYSAT-1474: Update DEFAULT_SAT_TAG to latest main build
Merge pull request #23 from Cray-HPE/CRAYSAT-1474-update-default-sat-tag
