### PR TITLE
Merge from integration_2022-07-05_15.03 to main (Cray-HPE/sat-podman) 07-05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.1] - 2022-07-05
+
+### Changed
+- Bumped the default tag for the ``cray/cray-sat`` container image that is
+  specified in the wrapper scripts from 3.17.0-20220627210641_7dd2953 to
+  3.17.1-20220705195400_fd46060.
+
 ## [1.9.0] - 2022-06-27
 
 ### Changed

--- a/cray-sat-podman.spec
+++ b/cray-sat-podman.spec
@@ -49,7 +49,7 @@ sat-podman is a wrapper to run the SAT CLI under podman
 for f in sat-podman.sh sat-manpage.sh; do
     # Use registry.local as it will work for both air-gapped and online installs
     sed -e 's,@DEFAULT_SAT_REPOSITORY@,registry.local/cray/cray-sat,' \
-        -e 's,@DEFAULT_SAT_TAG@,3.17.0-20220627210641_7dd2953,' \
+        -e 's,@DEFAULT_SAT_TAG@,3.17.1-20220705195400_fd46060,' \
         -i $f
 done
 # Build man pages


### PR DESCRIPTION
CRAYSAT-1482: Update DEFAULT_SAT_TAG to latest main build
Merge pull request #25 from Cray-HPE/CRAYSAT-1482-update-sat-tag
