### PR TITLE
CRAYSAT-1510: Use /opt/cray/etc/sat/version file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2022-08-09
+
+### Changed
+- Changed the wrapper scripts to depend on a file named ``/opt/cray/etc/sat/version``
+  to supply the version of the SAT container image, so that there is no longer
+  a hard-coded default SAT version in the script. When this file does not
+  exist, the following image is used:
+  ``registry.local/artifactory.algol60.net/sat-docker/stable/cray-sat:csm-latest``
+- Changed the ``SAT_REPOSITORY`` environment variable to no longer include
+  part of the image name.
+- Add a ``SAT_IMAGE_NAME`` variable so that the name of the image can
+  be specified.
+
 ## [1.9.1] - 2022-07-05
 
 ### Changed

--- a/cray-sat-podman.spec
+++ b/cray-sat-podman.spec
@@ -48,8 +48,9 @@ sat-podman is a wrapper to run the SAT CLI under podman
 # Replace values in sat and sat-man executables
 for f in sat-podman.sh sat-manpage.sh; do
     # Use registry.local as it will work for both air-gapped and online installs
-    sed -e 's,@DEFAULT_SAT_REPOSITORY@,registry.local/cray/cray-sat,' \
-        -e 's,@DEFAULT_SAT_TAG@,3.17.1-20220705195400_fd46060,' \
+    sed -e 's,@DEFAULT_SAT_REPOSITORY@,registry.local,' \
+        -e 's,@DEFAULT_SAT_IMAGE_NAME@,cray/cray-sat,' \
+        -e 's,@CSM_SAT_IMAGE_NAME@,artifactory.algol60.net/sat-docker/stable/cray-sat,' \
         -i $f
 done
 # Build man pages

--- a/man/sat-podman.8.rst
+++ b/man/sat-podman.8.rst
@@ -132,6 +132,11 @@ $HOME/.config/sat
         The directory is mounted in the container as /opt/cray/etc/release
         in read-only mode.
 
+/opt/cray/etc/sat/version
+        The file containing the version of the SAT container image to use.
+        When this file does not exist, the following image is used:
+        registry.local/artifactory.algol60.net/sat-docker/stable/cray-sat:csm-latest
+
 /var/log/cray/sat
         The directory containing the SAT log file.
         The directory is created if it does not exist.

--- a/sat-manpage.sh
+++ b/sat-manpage.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,8 +26,15 @@
 
 # Text surrounded by @ is replaced by a sed command in the spec file
 sat_repository=${SAT_REPOSITORY:-@DEFAULT_SAT_REPOSITORY@}
-sat_image_tag=${SAT_TAG:-@DEFAULT_SAT_TAG@}
-sat_image=${SAT_IMAGE:-$sat_repository:$sat_image_tag}
+sat_version_file="/opt/cray/etc/sat/version"
+if [[ -f "$sat_version_file" ]]; then
+    sat_image_name="${SAT_IMAGE_NAME:-@DEFAULT_SAT_IMAGE_NAME@}"
+    sat_image_tag="${SAT_TAG:-$(cat "$sat_version_file")}"
+else
+    sat_image_name="${SAT_IMAGE_NAME:-@CSM_SAT_IMAGE_NAME@}"
+    sat_image_tag="${SAT_TAG:-csm-latest}"
+fi
+sat_image="${SAT_IMAGE:-"${sat_repository}/${sat_image_name}:${sat_image_tag}"}"
 
 # either `sat-man sat` or `sat-man` with no arguments should bring up sat man page
 if [ -z "$1" ] || [ "$1" == 'sat' ]; then

--- a/sat-podman.sh
+++ b/sat-podman.sh
@@ -26,8 +26,15 @@
 
 # Text surrounded by @ is replaced by a sed command in the spec file
 sat_repository=${SAT_REPOSITORY:-@DEFAULT_SAT_REPOSITORY@}
-sat_image_tag=${SAT_TAG:-@DEFAULT_SAT_TAG@}
-sat_image=${SAT_IMAGE:-$sat_repository:$sat_image_tag}
+sat_version_file="/opt/cray/etc/sat/version"
+if [[ -f "$sat_version_file" ]]; then
+    sat_image_name="${SAT_IMAGE_NAME:-@DEFAULT_SAT_IMAGE_NAME@}"
+    sat_image_tag="${SAT_TAG:-$(cat "$sat_version_file")}"
+else
+    sat_image_name="${SAT_IMAGE_NAME:-@CSM_SAT_IMAGE_NAME@}"
+    sat_image_tag="${SAT_TAG:-csm-latest}"
+fi
+sat_image="${SAT_IMAGE:-"${sat_repository}/${sat_image_name}:${sat_image_tag}"}"
 
 nameserver=$(awk '{ if ($1 == "nameserver") { print $2; exit } }' /etc/resolv.conf )
 sat_dns_server=${SAT_DNS_SERVER:-$nameserver}


### PR DESCRIPTION
* Modify the sat-podman scripts to get the sat version from
  a static file. This makes it so that the sat-podman script
  and SAT container are no longer tightly coupled.
* When /etc/sat-version does not exist, assume the image is being
  provided by CSM.
* Fix SAT_REPOSITORY and SAT_IMAGE_NAME variables so that
  the image name is no longer part of the SAT_REPOSITORY variable.
* Declare version 2.0.0 in the change log

Test Description:
* After building the RPM, I packaged it into a development version
  of the product stream. This version of the product stream imports
  and runs Ansible configuration to write `/etc/sat-version` upon
  running the CFS configuration. When the RPM was installed, I ran
  `sat --version` to verify the new version.
* I removed `/etc/sat-version` to verify the default value of
  `registry.local/artifactory.algol60.net/sat-docker/stable/cray-sat:csm-latest`.
* I set environment variables SAT_IMAGE_NAME to cray/cray-sat and SAT_TAG
  to the value of /etc/sat-version (before it was deleted) to verify these
  variables could be used to override the default values.

## Issues and Related PRs

* Resolves [CRAYSAT-1510](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1510)

## Testing

See commit message 

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable