### PR TITLE
CRAYSAT-1542: Update sat container image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.2] - 2022-08-23
+
+### Fixed
+- Changed the default tag for the ``cray/cray-sat`` container image that is
+  specified in the wrapper scripts from 3.17.1-20220705195400_fd46060 to
+  3.17.1.
+
 ## [1.9.1] - 2022-07-05
 
 ### Changed

--- a/cray-sat-podman.spec
+++ b/cray-sat-podman.spec
@@ -49,7 +49,7 @@ sat-podman is a wrapper to run the SAT CLI under podman
 for f in sat-podman.sh sat-manpage.sh; do
     # Use registry.local as it will work for both air-gapped and online installs
     sed -e 's,@DEFAULT_SAT_REPOSITORY@,registry.local/cray/cray-sat,' \
-        -e 's,@DEFAULT_SAT_TAG@,3.17.1-20220705195400_fd46060,' \
+        -e 's,@DEFAULT_SAT_TAG@,3.17.1,' \
         -i $f
 done
 # Build man pages


### PR DESCRIPTION
This commit changest the default tag of cray-sat from
3.17.1-20220705195400_fd46060 to 3.17.1, which is the appropriate stable
build.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

