### PR TITLE
Merge from integration_2023-01-13_15.36 to main (Cray-HPE/sat-podman) 01-13

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -29,15 +29,20 @@ on:
 jobs:
   license-check:
     runs-on: ubuntu-latest
+
+    container:
+      image: artifactory.algol60.net/csm-docker/stable/license-checker:latest
+      credentials:
+          username: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
+          password: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
+
     steps:
     - uses: actions/checkout@v3
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v18.7
+      uses: tj-actions/changed-files@v34
 
     - name: License Check
       if: ${{ steps.changed-files.outputs.all_changed_files }}
-      uses: docker://artifactory.algol60.net/csm-docker/stable/license-checker:latest
-      with:
-        args: ${{ steps.changed-files.outputs.all_changed_files }}
+      run: /usr/local/bin/python3 /license_check/license_check.py ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,0 +1,43 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: Check Licenses
+
+on:
+  pull_request:
+
+jobs:
+  license-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v18.7
+
+    - name: License Check
+      if: ${{ steps.changed-files.outputs.all_changed_files }}
+      uses: docker://artifactory.algol60.net/csm-docker/stable/license-checker:latest
+      with:
+        args: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
CASMINST-5440: Use authentication when accessing license-checker image
Merge pull request #32 from Cray-HPE/CASMINST-5440-license-check-authentication
