### PR TITLE
CRAYSAT-1774: Build as noarch, noos, and publish to csm-rpms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2023-10-03
+
+### Changed
+- Changed RPM to noarch and noos and changed publishing location from sat-rpms
+  to csm-rpms in CSM Artifactory.
+
 ## [2.0.0] - 2022-08-09
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,6 +23,6 @@
 #
 # Dockerfile for building sat-podman. This installs the build dependencies.
 
-FROM artifactory.algol60.net/csm-docker/stable/csm-docker-sle:15.3
+FROM artifactory.algol60.net/csm-docker/stable/csm-docker-sle:15.5
 
 RUN zypper install --no-confirm python3-docutils

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -62,16 +62,14 @@ pipeline {
             steps {
                 script {
                     publishCsmRpms(
-                        artifactoryRepo: 'sat-rpms',
-                        os: 'sle-15sp3',
+                        os: 'noos',
                         component: env.NAME,
-                        pattern: 'dist/rpmbuild/RPMS/x86_64/*.rpm',
-                        arch: 'x86_64',
+                        pattern: 'dist/rpmbuild/RPMS/noarch/*.rpm',
+                        arch: 'noarch',
                         isStable: env.IS_STABLE
                     )
                     publishCsmRpms(
-                        artifactoryRepo: 'sat-rpms',
-                        os: 'sle-15sp3',
+                        os: 'noos',
                         component: env.NAME,
                         pattern: 'dist/rpmbuild/SRPMS/*.rpm',
                         arch: 'src',

--- a/cray-sat-podman.spec
+++ b/cray-sat-podman.spec
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,6 +33,7 @@ Source: %{name}-%{version}.tar.bz2
 Summary: SAT Podman
 Group: System/Management
 BuildRoot: %{_topdir}
+BuildArch: noarch
 Vendor: Hewlett Packard Enterprise Company
 Requires: podman
 Requires: podman-cni-config


### PR DESCRIPTION
## Summary and Scope

This RPM delivers only shell scripts and man pages, which means it is architecture-independent, so use noarch as the build architecture. It is also not very closely tied with a single SLES version, so publish it as a "noos" RPM like CSM has done for other RPMs which are not tied to specific SLES versions. Change the Docker image used to build to the version of SLES that matches the version on management nodes in CSM 1.5, which is SLES 15 SP5, not that it should matter much, given the independence from SLES versions discussed above.

In addition, publish to csm-rpms instead of to sat-rpms in preparation for merging the SAT product into the CSM product. This will make the RPMs available in the same repositories already in use by CSM. The `csm` repository will be updated to start including this `cray-sat-podman` RPM from this new location. The enables merging the SAT product into the CSM product.

While not required, it will also be a good idea to update the metal-provision repository to remove the old sat-rpms location once this is merged.

## Issues and Related PRs

* This is the first change for [CRAYSAT-1774](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1774)
* Change will also be needed in csm repo to pull in this new RPM

## Testing

### Tested on:

  * Mug

### Test description:
Pushed branch and checked where Jenkins published the RPM. Downloaded and inspected the RPM for correctness.

```
ncn-m001:~/haasken/rpms/extracted # rpm2cpio ../cray-sat-podman-2.1.0-1~craysat_1774_publish_to_csm_rpms~20231003211319.9392f72.noarch.rpm | cpio -idvmu
./usr/bin/sat
./usr/bin/sat-man
./usr/share/man/man8/sat-man.8.gz
./usr/share/man/man8/sat-podman.8.gz
./usr/share/man/man8/sat.8.gz
23 blocks
ncn-m001:~/haasken/rpms/extracted # ./usr/bin/sat --version
sat 3.25.0
```

## Risks and Mitigations

Should be pretty low-risk as the older versions of this RPM as well as older branches will still build and publish to the old location. Existing stable RPMs published to Artifactory should remain where they are, so nothing pulling those versions should break.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable