### PR TITLE
CRAYSAT-1771, CRAYSAT-1767: Use CSM image location in Nexus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-(C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.0.0] - 2023-10-24
+
+### Changed
+- Changed wrapper script logic to always use the `cray-sat` image path as
+  uploaded by the CSM product. This version of `sat-podman` requires that CSM
+  1.6 or later be installed because that is the version which began setting the
+  `cray-sat` image version in `/opt/cray/etc/sat/version`.
 
 ## [2.1.0] - 2023-10-03
 

--- a/cray-sat-podman.spec
+++ b/cray-sat-podman.spec
@@ -50,8 +50,7 @@ sat-podman is a wrapper to run the SAT CLI under podman
 for f in sat-podman.sh sat-manpage.sh; do
     # Use registry.local as it will work for both air-gapped and online installs
     sed -e 's,@DEFAULT_SAT_REPOSITORY@,registry.local,' \
-        -e 's,@DEFAULT_SAT_IMAGE_NAME@,cray/cray-sat,' \
-        -e 's,@CSM_SAT_IMAGE_NAME@,artifactory.algol60.net/sat-docker/stable/cray-sat,' \
+        -e 's,@CSM_SAT_IMAGE_NAME@,artifactory.algol60.net/csm-docker/stable/cray-sat,' \
         -i $f
 done
 # Build man pages

--- a/sat-manpage.sh
+++ b/sat-manpage.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -27,11 +27,10 @@
 # Text surrounded by @ is replaced by a sed command in the spec file
 sat_repository=${SAT_REPOSITORY:-@DEFAULT_SAT_REPOSITORY@}
 sat_version_file="/opt/cray/etc/sat/version"
+sat_image_name="${SAT_IMAGE_NAME:-@CSM_SAT_IMAGE_NAME@}"
 if [[ -f "$sat_version_file" ]]; then
-    sat_image_name="${SAT_IMAGE_NAME:-@DEFAULT_SAT_IMAGE_NAME@}"
     sat_image_tag="${SAT_TAG:-$(cat "$sat_version_file")}"
 else
-    sat_image_name="${SAT_IMAGE_NAME:-@CSM_SAT_IMAGE_NAME@}"
     sat_image_tag="${SAT_TAG:-csm-latest}"
 fi
 sat_image="${SAT_IMAGE:-"${sat_repository}/${sat_image_name}:${sat_image_tag}"}"

--- a/sat-podman.sh
+++ b/sat-podman.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -27,11 +27,10 @@
 # Text surrounded by @ is replaced by a sed command in the spec file
 sat_repository=${SAT_REPOSITORY:-@DEFAULT_SAT_REPOSITORY@}
 sat_version_file="/opt/cray/etc/sat/version"
+sat_image_name="${SAT_IMAGE_NAME:-@CSM_SAT_IMAGE_NAME@}"
 if [[ -f "$sat_version_file" ]]; then
-    sat_image_name="${SAT_IMAGE_NAME:-@DEFAULT_SAT_IMAGE_NAME@}"
     sat_image_tag="${SAT_TAG:-$(cat "$sat_version_file")}"
 else
-    sat_image_name="${SAT_IMAGE_NAME:-@CSM_SAT_IMAGE_NAME@}"
     sat_image_tag="${SAT_TAG:-csm-latest}"
 fi
 sat_image="${SAT_IMAGE:-"${sat_repository}/${sat_image_name}:${sat_image_tag}"}"


### PR DESCRIPTION
## Summary and Scope

Now that the CSM product includes the Ansible content that populates the
file `/opt/cray/etc/sat/version`, we should now use the path of that
image in Nexus as it is uploaded by CSM.

In addition, the cray-sat container image has moved from sat-docker to
csm-docker in Artifactory and Nexus, so update the default image name
used by the wrapper scripts accordingly.

Note that this is a backwards incompatible change, in that the wrapper
scripts will no longer work with the versions of the cray-sat container
image provided by the SAT product. This requires CSM 1.6.

## Issues and Related PRs

* Partially resolves [CRAYSAT-1767](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1767)
* Partially resolves [CRAYSAT-1771](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1771)

## Testing

### Tested on:

  * mug

### Test description:

Tested on mug as follows. First, used `podman push` to push a stable `cray-sat:3.25.5`
image to the new csm-docker location in Nexus both as the 3.25.5 tag and
as a csm-latest tag. This simulates the expected state of Nexus after a
CSM 1.6 install. Next, downloaded the `cray-sat-podman` RPM built from
this branch, extracted it, and executed the `sat` and `sat-man` scripts
it contained under the following conditions:

* No `/opt/cray/etc/sat/version` file present. In this case, it pulls
  the csm-latest tag from the new location in Nexus.
* The value `3.25.5` written to the file `/opt/cray/etc/sat/version`. In
  this case, it pulls that tag from the new location in Nexus.

The local `podman` image storage was cleared with `podman rmi` between
testing `sat` and `sat-podman` to be sure `sat-man` was pulling and using
the image from the new location.

## Risks and Mitigations

Although this is technically a backwards-incompatible behavior change, it is easy to use the environment variables supported by the wrapper scripts to point at the old image locations if needed.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable