### PR TITLE
CRAYSAT-1979: add visibility for environment variables inside of container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-(C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+(C) Copyright 2020-2023,2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.0.1] - 2025-06-03
+
+### Changed
+- Changed the sat-podman script to add visibility of the `SAT_CONFIG_FILE`
+  environment variable inside of the sat container.
 
 ## [3.0.0] - 2023-10-24
 

--- a/sat-podman.sh
+++ b/sat-podman.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023,2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -46,10 +46,18 @@ ceph_config_dir="/etc/ceph"
 cert_src_dir=${SAT_CERT_SRC_DIR:-/etc/pki/trust/anchors}
 cert_target_dir=${SAT_CERT_TARGET_DIR:-/usr/local/share/ca-certificates}
 kube_config_file=${SAT_KUBE_CONFIG_FILE:-/etc/kubernetes/admin.conf}
-sat_config_dir=${SAT_CONFIG_DIR:-$HOME/.config/sat/}
+sat_config_dir="$HOME/.config/sat/"
 sat_log_dir=${SAT_LOG_DIR:-/var/log/cray/sat/}
 
 podman_cli_args="--dns $sat_dns_server"
+
+if [[ -n $SAT_CONFIG_FILE ]]; then
+  sat_config_dir=$(dirname $SAT_CONFIG_FILE)
+  podman_cli_args="$podman_cli_args --env SAT_CONFIG_FILE=$SAT_CONFIG_FILE"
+elif [[ -n $SAT_CONFIG_DIR ]]; then
+  sat_config_dir=$SAT_CONFIG_DIR
+  podman_cli_args="$podman_cli_args --env SAT_CONFIG_FILE="$sat_config_dir/sat.toml""
+fi
 
 working_dir=$(pwd -P)
 if [ -d "$working_dir" ]; then
@@ -84,7 +92,7 @@ else
 fi
 # If configuration directory does not exist and cannot be created, then give a warning.
 if mkdir -p $sat_config_dir; then
-  podman_cli_args="$podman_cli_args --mount type=bind,src=$sat_config_dir,target=$HOME/.config/sat/"
+  podman_cli_args="$podman_cli_args --mount type=bind,src=$sat_config_dir,target=$sat_config_dir"
 else
   echo "WARNING: Unable to create sat configuration directory $sat_config_dir." \
        "No configuration file will be present." >&2


### PR DESCRIPTION
## Summary and Scope

Add visibility for environment variables inside of container

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1979](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1979)
* Change will also be needed in https://github.com/Cray-HPE/sat/pull/357

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * fanta
  * gamora
  * Local development environment

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_ 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? yes
- Were continuous integration tests run? If not, why? yes
- Was upgrade tested? If not, why? yes
- Was downgrade tested? If not, why? yes 
- Were new tests (or test issues/Jiras) created for this change? yes

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_ no


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

